### PR TITLE
Ensure all nutrient codes are valid in the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@
 
 # ignore Gemfile.lock - user should copy Gemfile.lock.linux or Gemfile.lock.mac to Gemfile.lock
 /Gemfile.lock
+
+# ignore O/S files
+.DS_Store

--- a/app/models/lookup_table.rb
+++ b/app/models/lookup_table.rb
@@ -1,5 +1,5 @@
 # Diet Support Program
-# Copyright (C) 2023 David A. Taylor of Taylored Web Sites (tayloredwebsites.com)
+# Copyright (C) 2024 David A. Taylor of Taylored Web Sites (tayloredwebsites.com)
 # Licensed under AGPL-3.0-only.  See https://opensource.org/license/agpl-v3/
 
 class LookupTable < ApplicationRecord
@@ -9,7 +9,6 @@ class LookupTable < ApplicationRecord
     "kG" => "Kilogram(s)",
     "mG" => "Miligram(s)",
     "uG" => "Microgram(s)",
-    "UG" => "Microgram(s)",
     "LB" => "Pound(s)",
     "OZ" => "Ounce(s)",
     "FL_OZ" => "Fluid Ounce(s)",
@@ -23,12 +22,15 @@ class LookupTable < ApplicationRecord
     "IU" => "International Units",
     "kCAL" => "Kilocalorie(s)",
     "kJ" => "Kilojoules",
-    "uG_RE" => "Microgram(s) (??)",
-    "uG_ATE" => "Miligram(s) (??)",
-    "uG_GAE" => "Miligram(s) (??)",
+    "mG_RE" => "Miligram(s) Retinol",
+    "mG_ATE" => "Miligram(s) Alpha Tocopherol Equivalents ",
+    "mG_GAE" => "Miligram(s) Gallic Acid",
+    "uG_RE" => "Microgram(s) Retinol",
+    "uG_ATE" => "Microgram(s) Alpha Tocopherol Equivalents ",
+    "uG_GAE" => "Microgram(s) Gallic Acid",
     "PH" => "Potential of Hydrogen (acid/alkaline)",
     "SP_GR" => "Specific Gravity",
-    "uMOL_TE" => "Micromole (??)",
+    "uMOL_TE" => "Micromole Trolox Equivalents",
   }.freeze
   
   DEPRECATED_UNIT_CODES = {

--- a/app/services/import_usda_csv_files.rb
+++ b/app/services/import_usda_csv_files.rb
@@ -981,7 +981,7 @@ class ImportUsdaCsvFiles
       current_unit_code = n.unit_code
       if LookupTable::DEPRECATED_UNIT_CODES[n.unit_code].present?
         new_unit_code = LookupTable::DEPRECATED_UNIT_CODES[n.unit_code]
-        msg = "#{n.name} unit code from #{current_unit_code} to #{new_unit_code}"
+        msg = "#{n.name} unit code from #{current_unit_code} to #{new_unit_code}."
         log_debug("*** To update #{msg}")
         n.unit_code = new_unit_code
         save_nutrient_rec = true
@@ -990,6 +990,13 @@ class ImportUsdaCsvFiles
         n.reload()
         log_debug("### Updated #{msg}")
         @report << "### Updated #{msg}"
+      elsif LookupTable::VALID_UNIT_CODES[n.unit_code].present?
+        msg = "#{n.name} unit code stays at #{current_unit_code}."
+        @report << "### OK #{msg}"
+      else
+        msg = "#{n.name} has invalid unit code of: #{current_unit_code}."
+        @report << "### Invalid unit code: #{msg}"
+        log_error("### Invalid unit code: #{msg}")
       end
       
     end


### PR DESCRIPTION
https://tayloredwebsites.atlassian.net/browse/DA-14

Step 7 of uploads uses the LookupTable::VALID_UNIT_CODES & LookupTable::DEPRECATED_UNIT_CODES to validate and replace deprecated code used in the Nutrients table.

ToDo: ensure there is only one valid record per nutrient name.  this will ensure that a nutrient will always be using the same record to avoid preventing thinking the nutrients are different because they have different records. See DA65